### PR TITLE
Copy-to-clipboard icon on phone numbers

### DIFF
--- a/frontend/components/Message.js
+++ b/frontend/components/Message.js
@@ -8,7 +8,7 @@ function Message({ message }) {
     <article className={'row'}>
       <div className={'meta'}>
           <MessageDate ts={message.ts} />
-          <span class={'from_txt'}> { message.fromNumber }</span>
+          <span className={'from_txt'}> { message.fromNumber }</span>
       </div>
       <div className={'message'}>
         <p>

--- a/frontend/containers/ActiveNumber.js
+++ b/frontend/containers/ActiveNumber.js
@@ -36,7 +36,7 @@ class ActiveNumber extends Component {
       <li>
         <i className={'active'}></i>
         <span
-          title={(this.copySupported && 'Click to copy to clipboard')}
+          title={(this.copySupported && 'Kopiera genom att klicka')}
           className={(this.copySupported && 'copy')}
           onClick={this.copyToClipboard}
         >

--- a/frontend/containers/ActiveNumber.js
+++ b/frontend/containers/ActiveNumber.js
@@ -1,0 +1,50 @@
+import React, { Component } from 'react'
+
+/**
+ * Single active number component
+ */
+class ActiveNumber extends Component {
+
+  constructor(props){
+    super(props)
+    // If browser supports copying
+    this.copySupported = document.queryCommandSupported('copy')
+  }
+
+  // Copy a number to clipboard
+  copyToClipboard = (e) => {
+
+    // Browser doesn't support copy command
+    if(!this.copySupported)
+      return
+
+    // Create a hidden (to avoid a flicker) textarea with
+    // the phone number as a value of it, copies that to
+    // clipboard and removes the element.
+    const tempTextarea = document.createElement('textarea')
+    tempTextarea.innerText = this.props.number
+    tempTextarea.className = 'hidden'
+    document.body.appendChild(tempTextarea)
+    tempTextarea.select()
+    document.execCommand('copy')
+    tempTextarea.remove()
+  };
+
+  render() {
+    const { number } = this.props
+    return (
+      <li>
+        <i className={'active'}></i>
+        <span
+          title={(this.copySupported && 'Click to copy to clipboard')}
+          className={(this.copySupported && 'copy')}
+          onClick={this.copyToClipboard}
+        >
+          { number }
+        </span>
+      </li>
+    )
+  }
+}
+
+export default ActiveNumber

--- a/frontend/containers/ActiveNumbersList.js
+++ b/frontend/containers/ActiveNumbersList.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { fetchNumbers } from '../actions/numbers'
+import ActiveNumber from './ActiveNumber'
 
 /**
  * Active numbers component to display list of numbers available
@@ -27,15 +28,9 @@ class ActiveNumbersList extends Component {
     const { numbers, loaded, error } = this.props
     return (
       <ul className={'number-list'}>
-        { numbers.map((number, i) => {
-          return (
-            <li key={i}>
-              <i className={'active'}></i>
-              <a href={ 'tel:'+number }>
-                { number }
-              </a>
-            </li>);
-        }) }
+        { numbers.map((number, i) => (
+          <ActiveNumber key={i} number={number} />
+        )) }
       </ul>
     )
   }

--- a/frontend/styles/_layout.scss
+++ b/frontend/styles/_layout.scss
@@ -36,3 +36,6 @@ body {
     flex-direction: column;
   }
 }
+.hidden {
+  opacity: 0;
+}

--- a/frontend/styles/_sidebar.scss
+++ b/frontend/styles/_sidebar.scss
@@ -19,6 +19,9 @@
           display:inline-block;
           margin-right: 6px;
         }
+        .copy {
+          cursor: pointer;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #22 

Click active phone number to copy it to clipboard if browser supports it.

Tested on:
- Chrome (73.0.3683.86)
- Safari (12.0)
- Firefox (65.0.1 & 68.0a1)